### PR TITLE
Fix compilation errors on Visual Studio 2015 (_MSC_VER 1900)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -284,6 +284,8 @@ if platform.is_msvc():
               '/wd4512', '/wd4800', '/wd4702', '/wd4819',
               # Disable warnings about passing "this" during initialization.
               '/wd4355',
+              # Disable warnings about ignored typedef in DbgHelp.h
+              '/wd4091',
               '/GR-',  # Disable RTTI.
               # Disable size_t -> int truncation warning.
               # We never have strings or arrays larger than 2**31.

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -239,13 +239,13 @@ bool DepsLog::Load(const string& path, State* state, string* err) {
       if (buf[path_size - 1] == '\0') --path_size;
       if (buf[path_size - 1] == '\0') --path_size;
       if (buf[path_size - 1] == '\0') --path_size;
-      StringPiece path(buf, path_size);
+      StringPiece subpath(buf, path_size);
       // It is not necessary to pass in a correct slash_bits here. It will
       // either be a Node that's in the manifest (in which case it will already
       // have a correct slash_bits that GetNode will look up), or it is an
       // implicit dependency from a .d which does not affect the build command
       // (and so need not have its slashes maintained).
-      Node* node = state->GetNode(path, 0);
+      Node* node = state->GetNode(subpath, 0);
 
       // Check that the expected index matches the actual index. This can only
       // happen if two ninja processes write to the same deps log concurrently.

--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -50,7 +50,22 @@ unsigned int MurmurHash2(const void* key, size_t len) {
   return h;
 }
 
-#ifdef _MSC_VER
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1900)
+#include <unordered_map>
+
+namespace std {
+template<>
+struct hash<StringPiece> {
+  typedef StringPiece argument_type;
+  typedef std::size_t result_type;
+
+  result_type operator()(argument_type const& s) const {
+    return MurmurHash2(s.str_, s.len_);
+  }
+};
+}
+
+#elif defined(_MSC_VER)
 #include <hash_map>
 
 using stdext::hash_map;
@@ -102,7 +117,9 @@ struct hash<StringPiece> {
 /// mapping StringPiece => Foo*.
 template<typename V>
 struct ExternalStringHashMap {
-#ifdef _MSC_VER
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1900)
+  typedef std::unordered_map<StringPiece, V> Type;
+#elif defined(_MSC_VER)
   typedef hash_map<StringPiece, V, StringPieceCmp> Type;
 #else
   typedef hash_map<StringPiece, V> Type;


### PR DESCRIPTION
Latest version of ``cl.exe`` complains about ignored typedef, hidden "path" local variable and hash_map being deprecated.

With C++11-compliant compilers (and MSC >= 1900), it is possible to use the standard unordered_map container instead of vendor-specific structures.