### PR TITLE
Remove an incorrect assert.

### DIFF
--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -891,6 +891,16 @@ TEST_F(ParserTest, DefaultDefault) {
   EXPECT_EQ("", err);
 }
 
+TEST_F(ParserTest, DefaultDefaultCycle) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(
+"rule cat\n  command = cat $in > $out\n"
+"build a: cat a\n"));
+
+  string err;
+  EXPECT_EQ(0u, state.DefaultNodes(&err).size());
+  EXPECT_EQ("could not determine root nodes of build graph", err);
+}
+
 TEST_F(ParserTest, DefaultStatements) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(
 "rule cat\n  command = cat $in > $out\n"

--- a/src/state.cc
+++ b/src/state.cc
@@ -187,7 +187,6 @@ vector<Node*> State::RootNodes(string* err) {
   if (!edges_.empty() && root_nodes.empty())
     *err = "could not determine root nodes of build graph";
 
-  assert(edges_.empty() || !root_nodes.empty());
   return root_nodes;
 }
 


### PR DESCRIPTION
The assert fires on cyclic manifests (found by afl-fuzz).  Since there
was explicit error handing for this case already, just remove the
assert.