### PR TITLE
POSIX: detach background subprocesses from terminal.

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -80,8 +80,11 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
         break;
 
       if (!use_console_) {
-        // Put the child in its own process group, so ctrl-c won't reach it.
-        if (setpgid(0, 0) < 0)
+        // Put the child in its own session and process group. It will be
+        // detached from the current terminal and ctrl-c won't reach it.
+        // Since this process was just forked, it is not a process group leader
+        // and setsid() will succeed.
+        if (setsid() < 0)
           break;
 
         // Open /dev/null over stdin.


### PR DESCRIPTION
Put background subprocesses (i.e. subprocesses with no access
to the console) in their own session and detach them from the
terminal.

This fixes martine/ninja#909.