### PR TITLE
Turn ninja_syntax.py into a PyPI package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 TAGS
 /build
 /build.ninja
+/misc/MANIFEST
+/misc/dist/
 /ninja
 /build_log_perftest
 /canon_perftest

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ TAGS
 /build
 /build.ninja
 /misc/MANIFEST
+/misc/version.py
 /misc/dist/
 /ninja
 /build_log_perftest

--- a/RELEASING
+++ b/RELEASING
@@ -7,13 +7,12 @@ Push new release branch:
 3. git checkout release; git merge master
 4. fix version number in src/version.cc (it will likely conflict in the above)
 5. fix version in doc/manual.asciidoc
-6. fix version number in misc/setup.py
-7. commit, tag, push (don't forget to push --tags)
+6. commit, tag, push (don't forget to push --tags)
        git commit -a -m v1.5.0; git push origin release
        git tag v1.5.0; git push --tags
        # Push the 1.5.0.git change on master too:
        git checkout master; git push origin master
-8. construct release notes from prior notes
+7. construct release notes from prior notes
    credits: git shortlog -s --no-merges REV..
 
 Release on github:

--- a/RELEASING
+++ b/RELEASING
@@ -7,17 +7,23 @@ Push new release branch:
 3. git checkout release; git merge master
 4. fix version number in src/version.cc (it will likely conflict in the above)
 5. fix version in doc/manual.asciidoc
-6. commit, tag, push (don't forget to push --tags)
+6. fix version number in misc/setup.py
+7. commit, tag, push (don't forget to push --tags)
        git commit -a -m v1.5.0; git push origin release
        git tag v1.5.0; git push --tags
        # Push the 1.5.0.git change on master too:
        git checkout master; git push origin master
-7. construct release notes from prior notes
+8. construct release notes from prior notes
    credits: git shortlog -s --no-merges REV..
 
 Release on github:
 1. https://github.com/blog/1547-release-your-software
    Add binaries to https://github.com/martine/ninja/releases
+
+Release on PyPI:
+1. http://peterdowns.com/posts/first-time-with-pypi.html
+2. Navigate to "misc" and execute
+       python setup.py sdist upload -r pypi
 
 Make announcement on mailing list:
 1. copy old mail

--- a/misc/MANIFEST.in
+++ b/misc/MANIFEST.in
@@ -1,4 +1,4 @@
 exclude *.py
-include __init__.py
 include ninja_syntax.py
+include version.py
 include setup.py

--- a/misc/MANIFEST.in
+++ b/misc/MANIFEST.in
@@ -1,0 +1,4 @@
+exclude *.py
+include __init__.py
+include ninja_syntax.py
+include setup.py

--- a/misc/__init__.py
+++ b/misc/__init__.py
@@ -1,4 +1,0 @@
-#!/usr/bin/python
-
-
-from ninja_syntax import Writer, escape, expand

--- a/misc/__init__.py
+++ b/misc/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python
+
+
+from ninja_syntax import Writer, escape, expand

--- a/misc/setup.py
+++ b/misc/setup.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+from distutils.core import setup
+
+
+setup(
+    name="ninja",
+    version="1.5.3",
+    description="Python module for generating .ninja files.",
+    license="Apache License (2.0)",
+    packages=["ninja"],
+    package_dir={"ninja": ""},
+    maintainer="Marat Dukhan",
+    maintainer_email="maratek@gmail.com",
+    url="https://github.com/martine/Ninja",
+    requires=[],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Other",
+        "Topic :: Software Development :: Build Tools"
+    ])

--- a/misc/setup.py
+++ b/misc/setup.py
@@ -1,15 +1,41 @@
 #!/usr/bin/python
 
 from distutils.core import setup
+import os
+import string
+import re
+
+
+def get_version():
+    version = None
+    try:
+        # First try to parse version from ../src/version.cc
+        with open(os.path.join(os.path.dirname(__file__), "..", "src", "version.cc")) as f:
+            for line in map(string.strip, f.readlines()):
+                m = re.match("const char\* kNinjaVersion = \"(\d+\.\d+\.\d+)\..+\";", line)
+                if m:
+                    version = m.group(1)
+    except IOError:
+        pass
+    if version is None:
+        # If file ../src/version.cc is not available (we are installing from source distribution),
+        # look up the previously generated version.py
+        version_globals = {}
+        execfile(os.path.join(os.path.dirname(__file__), "version.py"), version_globals)
+        version = version_globals["__version__"]
+    else:
+        # If version was parsed from ../src/version.cc, write it to version.py (see use above)
+        with open(os.path.join(os.path.dirname(__file__), "version.py"), "w") as f:
+            f.write("__version__ = \"" + version + "\"")
+    return version
 
 
 setup(
-    name="ninja",
-    version="1.5.3",
+    name="ninja_syntax",
+    version=get_version(),
     description="Python module for generating .ninja files.",
     license="Apache License (2.0)",
-    packages=["ninja"],
-    package_dir={"ninja": ""},
+    py_modules=["ninja_syntax"],
     maintainer="Marat Dukhan",
     maintainer_email="maratek@gmail.com",
     url="https://github.com/martine/Ninja",


### PR DESCRIPTION
The patch adds installation script and metadata to make a PyPI package out of `ninja_syntax.py` script.

Packaging `ninja_syntax.py` solves the problems discussed on `#ninja-build` mailing list [here](https://groups.google.com/forum/#!topic/ninja-build/PceLYvPJpKY).