### PR TITLE
subprocess_test: gracefully handle rlim.rlim_cur < kNumProcs

### DIFF
--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -177,8 +177,8 @@ TEST_F(SubprocessTest, SetWithLots) {
   // Make sure [ulimit -n] isn't going to stop us from working.
   rlimit rlim;
   ASSERT_EQ(0, getrlimit(RLIMIT_NOFILE, &rlim));
-  if (!EXPECT_GT(rlim.rlim_cur, kNumProcs)) {
-    printf("Raise [ulimit -n] well above %u to make this test go\n", kNumProcs);
+  if (rlim.rlim_cur < kNumProcs) {
+    printf("Raise [ulimit -n] well above %u (currently %lu) to make this test go\n", kNumProcs, rlim.rlim_cur);
     return;
   }
 


### PR DESCRIPTION
Instead of expecting that the number of open files is well above `kNumProcs`, simply "skip" the test in that case, still printing the message about the test limit (adding the current system limit too).

Theoretically, the `SubprocessTest.SetWithLots` test could be re-enabled on Mac OS X (whose soft file limit is less than 1025, according to the comment), but I don't have a Mac OS X system to test.