### PR TITLE
Allow duplicate rules with the same content

### DIFF
--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -66,6 +66,11 @@ void EvalString::AddSpecial(StringPiece text) {
   parsed_.push_back(make_pair(text.AsString(), SPECIAL));
 }
 
+size_t EvalString::hash() const {
+  std::hash<std::string> hash_fn;
+  return hash_fn(Serialize());
+}
+
 string EvalString::Serialize() const {
   string result;
   for (TokenList::const_iterator i = parsed_.begin();

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -65,6 +65,8 @@ struct EvalString {
   void AddText(StringPiece text);
   void AddSpecial(StringPiece text);
 
+  size_t hash() const;
+
   /// Construct a human-readable representation of the parsed state,
   /// for use in tests.
   string Serialize() const;

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -37,6 +37,18 @@ void Rule::AddBinding(const string& key, const EvalString& val) {
   bindings_[key] = val;
 }
 
+size_t Rule::hash() const {
+  std::hash<std::string> hash_fn;
+  size_t final_hash = hash_fn(name_);
+  map<string, EvalString>::const_iterator i;
+  for (i = bindings_.begin(); i != bindings_.end(); i++) {
+    // XOR the binding name with its EvalString and XOR all
+    // the bindings hashes to produce final_hash
+    final_hash ^= (hash_fn(i->first) ^ i->second.hash());
+  }
+  return final_hash;
+}
+
 const EvalString* Rule::GetBinding(const string& key) const {
   map<string, EvalString>::const_iterator i = bindings_.find(key);
   if (i == bindings_.end())

--- a/src/graph.h
+++ b/src/graph.h
@@ -134,6 +134,8 @@ struct Rule {
 
   const EvalString* GetBinding(const string& key) const;
 
+  size_t hash() const;
+
  private:
   // Allow the parsers to reach into this object and fill out its fields.
   friend struct ManifestParser;


### PR DESCRIPTION
Ninja disallowed duplicate rules with the same in the global
namespace. With this change, ninja allows duplicate rules with
*exactly* the same content. The content check is done by computing
and comparing the hash values of the rules.