### PR TITLE
Allow duplicate rules with the same content

### DIFF
--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -66,6 +66,15 @@ void EvalString::AddSpecial(StringPiece text) {
   parsed_.push_back(make_pair(text.AsString(), SPECIAL));
 }
 
+size_t EvalString::hash() const {
+#if (__cplusplus >= 201103L)
+  hash<string> hash_fn;
+#else
+  std::tr1::hash<string> hash_fn;
+#endif
+  return hash_fn(Serialize());
+}
+
 string EvalString::Serialize() const {
   string result;
   for (TokenList::const_iterator i = parsed_.begin();

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -18,6 +18,11 @@
 #include <map>
 #include <string>
 #include <vector>
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1800)
+#include <functional>
+#else
+#include <tr1/functional>
+#endif
 using namespace std;
 
 #include "string_piece.h"
@@ -64,6 +69,8 @@ struct EvalString {
 
   void AddText(StringPiece text);
   void AddSpecial(StringPiece text);
+
+  size_t hash() const;
 
   /// Construct a human-readable representation of the parsed state,
   /// for use in tests.

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -37,6 +37,22 @@ void Rule::AddBinding(const string& key, const EvalString& val) {
   bindings_[key] = val;
 }
 
+size_t Rule::hash() const {
+#if (__cplusplus >= 201103L)
+  hash<string> hash_fn;
+#else
+  std::tr1::hash<string> hash_fn;
+#endif
+  size_t final_hash = hash_fn(name_);
+  map<string, EvalString>::const_iterator i;
+  for (i = bindings_.begin(); i != bindings_.end(); i++) {
+    // XOR the binding name with its EvalString and XOR all
+    // the bindings hashes to produce final_hash
+    final_hash ^= (hash_fn(i->first) ^ i->second.hash());
+  }
+  return final_hash;
+}
+
 const EvalString* Rule::GetBinding(const string& key) const {
   map<string, EvalString>::const_iterator i = bindings_.find(key);
   if (i == bindings_.end())

--- a/src/graph.h
+++ b/src/graph.h
@@ -17,6 +17,12 @@
 
 #include <string>
 #include <vector>
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1800)
+#include <functional>
+#else
+#include <tr1/functional>
+using namespace std::tr1;
+#endif
 using namespace std;
 
 #include "eval_env.h"
@@ -133,6 +139,8 @@ struct Rule {
   static bool IsReservedBinding(const string& var);
 
   const EvalString* GetBinding(const string& key) const;
+
+  size_t hash() const;
 
  private:
   // Allow the parsers to reach into this object and fill out its fields.


### PR DESCRIPTION
Ninja till now disallowed duplicate rules with the same name
in the global namespace. With this change, ninja allows duplicate
rules with *exactly* the same content. The content check is done
by computing and comparing the hash values of the rules' content.

This change was tested using the following compilers:
 - MSVC 18.00.21005.1 for x64
 - g++ 4.9.2