### PR TITLE
On unexpected output in a .d file, rebuild instead erroring.

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -816,8 +816,7 @@ TEST_F(BuildTest, DepFileParseError) {
   fs_.Create("foo.c", "");
   fs_.Create("foo.o.d", "randomtext\n");
   EXPECT_FALSE(builder_.AddTarget("foo.o", &err));
-  EXPECT_EQ("expected depfile 'foo.o.d' to mention 'foo.o', got 'randomtext'",
-            err);
+  EXPECT_EQ("foo.o.d: expected ':' in depfile", err);
 }
 
 TEST_F(BuildTest, OrderOnlyDeps) {

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -2042,6 +2042,23 @@ TEST_F(BuildWithDepsLogTest, RestatMissingDepfileDepslog) {
   ASSERT_EQ(0u, command_runner_.commands_ran_.size());
 }
 
+TEST_F(BuildTest, WrongOutputInDepfileCausesRebuild) {
+  string err;
+  const char* manifest =
+"rule cc\n"
+"  command = cc $in\n"
+"  depfile = $out.d\n"
+"build foo.o: cc foo.c\n";
+
+  fs_.Create("foo.c", "");
+  fs_.Create("foo.o", "");
+  fs_.Create("header.h", "");
+  fs_.Create("foo.o.d", "bar.o.d: header.h\n");
+
+  RebuildTarget("foo.o", manifest, "build_log", "ninja_deps");
+  ASSERT_EQ(1u, command_runner_.commands_ran_.size());
+}
+
 TEST_F(BuildTest, Console) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule console\n"

--- a/src/depfile_parser.cc
+++ b/src/depfile_parser.cc
@@ -230,5 +230,9 @@ yy16:
       return false;
     }
   }
+  if (parsing_targets) {
+    *err = "expected ':' in depfile";
+    return false;
+  }
   return true;
 }

--- a/src/depfile_parser.in.cc
+++ b/src/depfile_parser.in.cc
@@ -112,5 +112,9 @@ bool DepfileParser::Parse(string* content, string* err) {
       return false;
     }
   }
+  if (parsing_targets) {
+    *err = "expected ':' in depfile";
+    return false;
+  }
   return true;
 }

--- a/src/depfile_parser_test.cc
+++ b/src/depfile_parser_test.cc
@@ -106,7 +106,7 @@ TEST_F(DepfileParserTest, Escapes) {
   // it through.
   string err;
   EXPECT_TRUE(Parse(
-"\\!\\@\\#$$\\%\\^\\&\\\\",
+"\\!\\@\\#$$\\%\\^\\&\\\\:",
       &err));
   ASSERT_EQ("", err);
   EXPECT_EQ("\\!\\@#$\\%\\^\\&\\",

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -390,12 +390,13 @@ bool ImplicitDepLoader::LoadDepFile(Edge* edge, const string& path,
                         &depfile.out_.len_, &unused, err))
     return false;
 
-  // Check that this depfile matches the edge's output.
+  // Check that this depfile matches the edge's output, if not return false to
+  // mark the edge as dirty.
   Node* first_output = edge->outputs_[0];
   StringPiece opath = StringPiece(first_output->path());
   if (opath != depfile.out_) {
-    *err = "expected depfile '" + path + "' to mention '" +
-        first_output->path() + "', got '" + depfile.out_.AsString() + "'";
+    EXPLAIN("expected depfile '%s' to mention '%s', got '%s'", path.c_str(),
+            first_output->path().c_str(), depfile.out_.AsString().c_str());
     return false;
   }
 


### PR DESCRIPTION
Fixes #417.  Also make .d files without a `:` an error (before, invalid depfiles were found by the output check that's now being removed.)