### PR TITLE
Don't crash on cyclic references between rule bindings.

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -226,6 +226,7 @@ struct EdgeEnv : public Env {
                       vector<Node*>::iterator end,
                       char sep);
 
+  vector<string> lookups_;
   Edge* edge_;
   EscapeKind escape_in_out_;
 };
@@ -243,8 +244,19 @@ string EdgeEnv::LookupVariable(const string& var) {
                         ' ');
   }
 
+  vector<string>::const_iterator it;
+  if ((it = find(lookups_.begin(), lookups_.end(), var)) != lookups_.end()) {
+    string cycle;
+    for (; it != lookups_.end(); ++it)
+      cycle.append(*it + " -> ");
+    cycle.append(var);
+    Fatal(("cycle in rule variables: " + cycle).c_str());
+  }
+
   // See notes on BindingEnv::LookupWithFallback.
   const EvalString* eval = edge_->rule_->GetBinding(var);
+  if (eval)
+    lookups_.push_back(var);
   return edge_->env_->LookupWithFallback(var, eval, this);
 }
 

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -321,6 +321,7 @@ bool ManifestParser::ParseEdge(string* err) {
     edge->pool_ = pool;
   }
 
+  edge->outputs_.reserve(outs.size());
   for (vector<EvalString>::iterator i = outs.begin(); i != outs.end(); ++i) {
     string path = i->Evaluate(env);
     string path_err;
@@ -337,6 +338,7 @@ bool ManifestParser::ParseEdge(string* err) {
     return true;
   }
 
+  edge->inputs_.reserve(ins.size());
   for (vector<EvalString>::iterator i = ins.begin(); i != ins.end(); ++i) {
     string path = i->Evaluate(env);
     string path_err;


### PR DESCRIPTION
Fixes #902.

I considered two approaches:

1. Find cycles between rule variables when parsing rules. This is
   nice because there usually aren't many rules, so it's ok if this takes
   some time.  Also, it makes it possible to use lexer_.Error() for a nice
   error message.
   
   On the flipside, it doesn't work with the current rspfile logic: ninja
   currently also checks statically that both rspfile and rspfile_contents
   are set on a rule, so one has to write
   
        rule foo
          rspfile = $rspfile
          rspfile_content = actual content
        build out: foo in
          rspfile = actual.rsp

   to work around this static checking  -- and that's a static cycle for
   `rspfile`.  We could make the rspfile / rspfile_content check dynamic,
   but many ninja files out there probably contain these cycles, so this
   isn't a fix that'll work in practice :-(

2. Dynamically while evaluating variables, let the EdgeEnv keep track
   of the variables that have been evaluated, and error out if one is
   evaluated twice.  This has the disadvantage that the naive way of
   doing it regresses performance, but that can be mitigated by being
   careful (commit 2 in this pull request).  It's also not easy to print a
   nice error message at this point, we just fail with `Fatal()`.  Since
   I've never seen anyone hit this in practice and this fix is to make
   afl-fuzz not report any crashes (yay!), that's ok.  No tests for the
   same reason.  Tested manually with
   
        rule r
          command = $description
          description = $command
    
        build a: r b
          command = foo
        build b: r c
          description = adsf
        build d: r b

   The first two edges are fine, the third one should error instead of crashing.