### PR TITLE
Don't get stuck on cyclic graphs where one edge has multiple outputs.

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -201,6 +201,43 @@ TEST_F(PlanTest, DependencyCycle) {
   ASSERT_EQ("dependency cycle: out -> mid -> in -> pre -> out", err);
 }
 
+TEST_F(PlanTest, CycleInEdgesButNotInNodes1) {
+  string err;
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"build a b: cat a\n"));
+  EXPECT_FALSE(plan_.AddTarget(GetNode("b"), &err));
+  ASSERT_EQ("dependency cycle: a -> a", err);
+}
+
+TEST_F(PlanTest, CycleInEdgesButNotInNodes2) {
+  string err;
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"build b a: cat a\n"));
+  EXPECT_FALSE(plan_.AddTarget(GetNode("b"), &err));
+  ASSERT_EQ("dependency cycle: a -> a", err);
+}
+
+TEST_F(PlanTest, CycleInEdgesButNotInNodes3) {
+  string err;
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"build a b: cat c\n"
+"build c: cat a\n"));
+  EXPECT_FALSE(plan_.AddTarget(GetNode("b"), &err));
+  ASSERT_EQ("dependency cycle: c -> a -> c", err);
+}
+
+TEST_F(PlanTest, CycleInEdgesButNotInNodes4) {
+  string err;
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"build d: cat c\n"
+"build c: cat b\n"
+"build b: cat a\n"
+"build a e: cat d\n"
+"build f: cat e\n"));
+  EXPECT_FALSE(plan_.AddTarget(GetNode("f"), &err));
+  ASSERT_EQ("dependency cycle: d -> c -> b -> a -> d", err);
+}
+
 void PlanTest::TestPoolWithDepthOne(const char* test_case) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_, test_case));
   GetNode("out1")->MarkDirty();


### PR DESCRIPTION
Fixes #934. Plan::AddSubTarget() tracks in want_ if each edge has been
visited and visits every edge only once.  But Plan::CheckDependencyCycle()
worked on nodes however, so if a cycle was entered through an edge with
multiple outputs, ninja would fail to detect that cycle.

Move cycle detection to look for duplicate edges instead of nodes to fix
this.  The extra jump makes CheckDependencyCycle() a bit slower: for a
synthetic build file with 10000 serial build steps, `ninja -n` now takes
0.32s instead of 0.26s before on my laptop.  In practice, projects have
a dependency change length on the order of 50, so there shouldn't be a
noticeable slowdown in practice.  (If this does end up being a problem:
CheckDependencyCycle() currently does O(n) work and is called O(m) times
from AddSubTarget(), so I think cycle checking is O(n^2) in the build
depth.  So instead of worrying about constant overhead, we could use
a set<> instead of a stack<>.  But it doesn't seem to be a problem in
practice.)