### PR TITLE
Run more than 34 processes on Win32 if we have 32+ cores.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -500,7 +500,7 @@ string StripAnsiEscapeCodes(const string& in) {
 int GetProcessorCount() {
 #ifdef _WIN32
   SYSTEM_INFO info;
-  GetSystemInfo(&info);
+  GetNativeSystemInfo(&info);
   return info.dwNumberOfProcessors;
 #else
   return sysconf(_SC_NPROCESSORS_ONLN);


### PR DESCRIPTION
For a compatiblity reason, dwNumberOfProcessors in Win32 is capped at 32.
So even if your machine has more than 32 cores, Ninja spawns at most 34
subprocesses if compiled as 32 bit application. This patch fixes the issue by
using GetNativeSystemInfo, which returns the system info from Wow64 point
of view, instead of GetSystemInfo.

GetNativeSystemInfo is supported since Windows XP or Windows Server 2003.