### PR TITLE
Fix pool use count going unbalanced

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -374,24 +374,19 @@ void Plan::ScheduleWork(Edge* edge) {
   }
 }
 
-void Plan::ResumeDelayedJobs(Edge* edge) {
-  edge->pool()->EdgeFinished(*edge);
-  edge->pool()->RetrieveReadyEdges(&ready_);
-}
-
-void Plan::EdgeFinished(Edge* edge, bool directly_wanted) {
+void Plan::EdgeFinished(Edge* edge) {
   map<Edge*, bool>::iterator e = want_.find(edge);
   assert(e != want_.end());
-  if (e->second)
+  bool directly_wanted = e->second;
+  if (directly_wanted)
     --wanted_edges_;
   want_.erase(e);
   edge->outputs_ready_ = true;
 
-  // See if this job frees up any delayed jobs
+  // See if this job frees up any delayed jobs.
   if (directly_wanted)
-    ResumeDelayedJobs(edge);
-  else
-    edge->pool()->RetrieveReadyEdges(&ready_);
+    edge->pool()->EdgeFinished(*edge);
+  edge->pool()->RetrieveReadyEdges(&ready_);
 
   // Check off any nodes we were waiting for with this edge.
   for (vector<Node*>::iterator o = edge->outputs_.begin();
@@ -415,7 +410,7 @@ void Plan::NodeFinished(Node* node) {
       } else {
         // We do not need to build this edge, but we might need to build one of
         // its dependents.
-        EdgeFinished(*oe, want_e->second);
+        EdgeFinished(*oe);
       }
     }
   }

--- a/src/build.cc
+++ b/src/build.cc
@@ -411,7 +411,9 @@ void Plan::NodeFinished(Node* node) {
         ScheduleWork(*oe);
       } else {
         // We do not need to build this edge, but we might need to build one of
-        // its dependents.
+        // its dependents. Make sure the pool schedules it before it's finished
+        // otherwise the pool use count may be invalid.
+        (*oe)->pool()->EdgeScheduled(**oe);
         EdgeFinished(*oe);
       }
     }

--- a/src/build.h
+++ b/src/build.h
@@ -58,7 +58,7 @@ struct Plan {
 
   /// Mark an edge as done building.  Used internally and by
   /// tests.
-  void EdgeFinished(Edge* edge);
+  void EdgeFinished(Edge* edge, bool directly_wanted = true);
 
   /// Clean the given node during the build.
   /// Return false on error.

--- a/src/build.h
+++ b/src/build.h
@@ -58,7 +58,7 @@ struct Plan {
 
   /// Mark an edge as done building.  Used internally and by
   /// tests.
-  void EdgeFinished(Edge* edge, bool directly_wanted = true);
+  void EdgeFinished(Edge* edge);
 
   /// Clean the given node during the build.
   /// Return false on error.
@@ -77,11 +77,6 @@ private:
   /// The edge may be delayed from running, for example if it's a member of a
   /// currently-full pool.
   void ScheduleWork(Edge* edge);
-
-  /// Allows jobs blocking on |edge| to potentially resume.
-  /// For example, if |edge| is a member of a pool, calling this may schedule
-  /// previously pending jobs in that pool.
-  void ResumeDelayedJobs(Edge* edge);
 
   /// Keep track of which edges we want to build in this plan.  If this map does
   /// not contain an entry for an edge, we do not want to build the entry or its

--- a/src/state.h
+++ b/src/state.h
@@ -44,6 +44,7 @@ struct Pool {
   bool is_valid() const { return depth_ >= 0; }
   int depth() const { return depth_; }
   const string& name() const { return name_; }
+  int current_use() const { return current_use_; }
 
   /// true if the Pool might delay this edge
   bool ShouldDelayEdge() const { return depth_ != 0; }

--- a/src/state.h
+++ b/src/state.h
@@ -71,9 +71,6 @@ struct Pool {
 
   /// |current_use_| is the total of the weights of the edges which are
   /// currently scheduled in the Plan (i.e. the edges in Plan::ready_).
-  /// This is generally <= to depth_. It can exceed it very briefly when the
-  /// pool is notified about an edge that's about to be finished that will
-  /// not actually be started. See Plan::NodeFinished().
   int current_use_;
   int depth_;
 

--- a/src/state.h
+++ b/src/state.h
@@ -71,6 +71,9 @@ struct Pool {
 
   /// |current_use_| is the total of the weights of the edges which are
   /// currently scheduled in the Plan (i.e. the edges in Plan::ready_).
+  /// This is generally <= to depth_. It can exceed it very briefly when the
+  /// pool is notified about an edge that's about to be finished that will
+  /// not actually be started. See Plan::NodeFinished().
   int current_use_;
   int depth_;
 


### PR DESCRIPTION
When a Node was finished, but its output edge was not directly needed, the pool use count would be decremented for that edge without ever having been incremented. This could result in the pool use count going below 0, so that future edges scheduled for that pool would not respect the pool's limit. This is a fix for #959.