### PR TITLE
Set close-on-exec for pipe writer in console mode

### DIFF
--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -96,6 +96,8 @@ struct SubprocessSet {
 
   static bool IsInterrupted() { return interrupted_ != 0; }
 
+  void CheckDoneConsoleProcesses(bool block);
+
   struct sigaction old_int_act_;
   struct sigaction old_term_act_;
   sigset_t old_mask_;


### PR DESCRIPTION
The pipe isn't used by subprocesses in console mode,
so close it. This avoids the possibility of the FD
being leaked into nested subprocesses, causing Ninja
to hang like in #965.