### PR TITLE
Wake ppoll/pselect on SIGCHLD

### DIFF
--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -100,6 +100,10 @@ struct SubprocessSet {
   void HandleChildExit();
   static void SetChildExited(int signum);
   static bool child_exited_;
+#if !defined(USE_PPOLL)
+  static int self_pipe_[2];
+#endif
+  static void SignalHandled();
 
   struct sigaction old_int_act_;
   struct sigaction old_term_act_;

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -63,6 +63,7 @@ struct Subprocess {
 #else
   int fd_;
   pid_t pid_;
+  int status_;
 #endif
   bool use_console_;
 
@@ -96,8 +97,13 @@ struct SubprocessSet {
 
   static bool IsInterrupted() { return interrupted_ != 0; }
 
+  void HandleChildExit();
+  static void SetChildExited(int signum);
+  static bool child_exited_;
+
   struct sigaction old_int_act_;
   struct sigaction old_term_act_;
+  struct sigaction old_chld_act_;
   sigset_t old_mask_;
 #endif
 };

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -261,3 +261,17 @@ TEST_F(SubprocessTest, ReadStdin) {
   ASSERT_EQ(1u, subprocs_.finished_.size());
 }
 #endif  // _WIN32
+
+#ifndef _WIN32
+TEST_F(SubprocessTest, Background) {
+  time_t before = time(NULL);
+  Subprocess* subproc = subprocs_.Add("echo -n 123; sleep 2s&");
+  while (!subproc->Done())
+    subprocs_.DoWork();
+  time_t after = time(NULL);
+  ASSERT_LE(after-before, 1);
+  ASSERT_EQ(ExitSuccess, subproc->Finish());
+  ASSERT_EQ("123", subproc->GetOutput());
+  ASSERT_EQ(1u, subprocs_.finished_.size());
+}
+#endif

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -274,4 +274,12 @@ TEST_F(SubprocessTest, Background) {
   ASSERT_EQ("123", subproc->GetOutput());
   ASSERT_EQ(1u, subprocs_.finished_.size());
 }
+
+TEST_F(SubprocessTest, ExitBeforePoll) {
+  kill(getpid(), SIGINT); // should be blocked until ppoll/pselect
+  bool interrupted = subprocs_.DoWork();
+  if (interrupted)
+    return;
+  ASSERT_FALSE("We should have been interrupted");
+}
 #endif

--- a/src/util.cc
+++ b/src/util.cc
@@ -411,6 +411,17 @@ void SetCloseOnExec(int fd) {
 #endif  // ! _WIN32
 }
 
+#ifndef _WIN32
+void SetNonBlocking(int fd) {
+  int flags = fcntl(fd, F_GETFL);
+  if (flags < 0) {
+    perror("fcntl(F_GETFL)");
+  } else {
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0)
+      perror("fcntl(F_SETFL)");
+  }
+}
+#endif
 
 const char* SpellcheckStringV(const string& text,
                               const vector<const char*>& words) {

--- a/src/util.h
+++ b/src/util.h
@@ -62,6 +62,11 @@ int ReadFile(const string& path, string* contents, string* err);
 /// Mark a file descriptor to not be inherited on exec()s.
 void SetCloseOnExec(int fd);
 
+#ifndef _WIN32
+/// Mark a file descriptor as non-blocking.
+void SetNonBlocking(int fd);
+#endif
+
 /// Given a misspelled string and a list of correct spellings, returns
 /// the closest match or NULL if there is no close enough match.
 const char* SpellcheckStringV(const string& text,


### PR DESCRIPTION
This change introduces a sigaction for
SIGCHLD, which causes ppoll and pselect
to return -1/EINTR if a child dies before
a pipe becomes readable. We then check
for dead children, leaving them in a
waitable state for Finish.

Fixes #965
Obsoletes #966