### PR TITLE
Bootstrap out of source

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -355,6 +355,9 @@ if platform.supports_ppoll() and not options.force_pselect:
 if platform.supports_ninja_browse():
     cflags.append('-DNINJA_HAVE_BROWSE')
 
+# Search for generated headers relative to build dir.
+cflags.append('-I.')
+
 def shell_escape(str):
     """Escape str such that it's interpreted as a single argument by
     the shell."""

--- a/src/browse.cc
+++ b/src/browse.cc
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include "../build/browse_py.h"
+#include "build/browse_py.h"
 
 void RunBrowsePython(State* state, const char* ninja_command,
                      const char* initial_target) {


### PR DESCRIPTION
This allows ninja to bootstrap out of source. It works the expected way:

mkdir my_build_dir
cd my_build_dir
/full/path/to/ninja/configure.py --bootstrap

It's split into two commits for clarity. The first adds a $sourcedir variable to the ninja script and makes all source files relative to it. The second fixes inclusion of the generated header.

Is there any interest in this?