### PR TITLE
Add missing member initializer in Edge constructor

### DIFF
--- a/src/graph.h
+++ b/src/graph.h
@@ -122,7 +122,8 @@ private:
 
 /// An edge in the dependency graph; links between Nodes using Rules.
 struct Edge {
-  Edge() : rule_(NULL), env_(NULL), outputs_ready_(false), deps_missing_(false),
+  Edge() : rule_(NULL), pool_(NULL), env_(NULL),
+           outputs_ready_(false), deps_missing_(false),
            implicit_deps_(0), order_only_deps_(0) {}
 
   /// Return true if all inputs' in-edges are ready.


### PR DESCRIPTION
In commit v1.1.0^2~15^2~20 (stub out an api and de-constify Pool,
2012-10-03) the Edge "pool_" member was added as a raw pointer but the
initializer was accidentally left out of the constructor.  Add it now.