### PR TITLE
Bootstrap out of source

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -355,6 +355,9 @@ if platform.supports_ppoll() and not options.force_pselect:
 if platform.supports_ninja_browse():
     cflags.append('-DNINJA_HAVE_BROWSE')
 
+# Search for generated headers relative to build dir.
+cflags.append('-I.')
+
 def shell_escape(str):
     """Escape str such that it's interpreted as a single argument by
     the shell."""

--- a/configure.py
+++ b/configure.py
@@ -156,11 +156,15 @@ class Bootstrap:
     def _expand_paths(self, paths):
         """Expand $vars in an array of paths, e.g. from a 'build' block."""
         paths = ninja_syntax.as_list(paths)
-        return ' '.join(map(self._expand, paths))
+        return ' '.join(map(self._shell_escape, (map(self._expand, paths))))
 
     def _expand(self, str, local_vars={}):
         """Expand $vars in a string."""
         return ninja_syntax.expand(str, self.vars, local_vars)
+
+    def _shell_escape(self, path):
+        """Quote paths containing spaces."""
+        return '"%s"' % path if ' ' in path else path
 
     def _run_command(self, cmdline):
         """Run a subcommand, quietly.  Prints the full command on error."""
@@ -420,7 +424,7 @@ objs = []
 if platform.supports_ninja_browse():
     n.comment('browse_py.h is used to inline browse.py.')
     n.rule('inline',
-           command=src('inline.sh') + ' $varname < $in > $out',
+           command='"%s"' % src('inline.sh') + ' $varname < $in > $out',
            description='INLINE $out')
     n.build(built('browse_py.h'), 'inline', src('browse.py'),
             implicit=src('inline.sh'),

--- a/src/browse.cc
+++ b/src/browse.cc
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include "../build/browse_py.h"
+#include "build/browse_py.h"
 
 void RunBrowsePython(State* state, const char* ninja_command,
                      const char* initial_target) {


### PR DESCRIPTION
Reopening #971. The fix involves emulating the same kind of shell escaping as ninja in the configure script bootstrap compile commands. Only checks for the bare minimum to fix the case of paths containing spaces. Ninja checks for a bunch of other special characters. The inline.sh command also needed to be quoted in the generated build script.