### PR TITLE
point people at more detailed build docs if they're on Windows

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -2,10 +2,26 @@
 
 `./configure.py` generates the `build.ninja` files used to build
 ninja.  It accepts various flags to adjust build parameters.
+Run './configure.py --help' for more configuration options.
 
 The primary build target of interest is `ninja`, but when hacking on
-Ninja your changes should be testable so it's more useful to build
-and run `ninja_test` when developing.
+Ninja your changes should be testable so it's more useful to build and
+run `ninja_test` when developing.
+
+### Bootstrapping
+
+Ninja is built using itself.  To bootstrap the first binary, run the
+configure script as `./configure.py --bootstrap`.  It This first
+compiles all non-test source files together, then re-builds Ninja
+using itself.  You should end up with a `ninja' binary (or
+`ninja.exe`) in the source root.
+
+#### Windows
+
+On Windows, you'll need to install Python to run `configure.py`, and
+run everything under a Visual Studio Tools Command Prompt (or after
+running `vcvarsall` in a normal command prompt).  See below if you
+want to use mingw or some other compiler instead using Visual Studio.
 
 ### Adjusting build flags
 

--- a/README
+++ b/README
@@ -5,12 +5,13 @@ See the manual -- http://martine.github.com/ninja/manual.html or
 doc/manual.asciidoc included in the distribution -- for background
 and more details.
 
-To build, run ./configure.py --bootstrap.  It first compiles all non-test
-source files together, then re-builds Ninja using itself.  You should
-end up with a 'ninja' binary in the source root.
-
-Run './configure.py --help' for more configuration options.
+Binaries for Linux, Mac, and Windows are available at
+  https://github.com/martine/ninja/releases
 Run './ninja -h' for Ninja help.
+
+To build your own binary, on many platforms it should be sufficient to
+just run `./configure.py --bootstrap`; for more details see HACKING.md.
+(Also read that before making changes to Ninja, as it has advice.)
 
 Installation is not necessary because the only required file is is the
 resulting ninja binary. However, to enable features like Bash


### PR DESCRIPTION
It's a hard balance between "most people want to run configure --bootstrap" and
"here's a massive wall of text of every detail about building".  I think the
balance in this change is better than it was before -- most people on Windows
don't want to build their own binary.

Fixes #983.