### PR TITLE
Add null.o to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ TAGS
 /doc/doxygen
 /gtest-1.6.0
 *.patch
+/null.o
 
 # Eclipse project files
 .project


### PR DESCRIPTION
This file seems to be popping up across all builds of Ninja, dirtying up submodules and such.

On Mac Yosemite, clang info

```
Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.1.0
Thread model: posix
```