### PR TITLE
Optimize StringPiece hash map

### DIFF
--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -76,7 +76,7 @@ struct StringPieceCmp : public hash_compare<StringPiece> {
     return MurmurHash2(key.str_, key.len_);
   }
   bool operator()(const StringPiece& a, const StringPiece& b) const {
-    int cmp = strncmp(a.str_, b.str_, min(a.len_, b.len_));
+    int cmp = memcmp(a.str_, b.str_, min(a.len_, b.len_));
     if (cmp < 0) {
       return true;
     } else if (cmp > 0) {


### PR DESCRIPTION
Replace strncmp with memcmp to improve runtime performance.

Sorry for not having any figures to prove it, but I tried this ages ago.